### PR TITLE
Added explicit production=false to install command

### DIFF
--- a/src/Cake.Yarn.Tests/YarnInstallTests.cs
+++ b/src/Cake.Yarn.Tests/YarnInstallTests.cs
@@ -23,13 +23,23 @@ namespace Cake.Yarn.Tests
         }
 
         [Fact]
-        public void Packages_And_ForProduction_Settings_Specified_Should_Use_Throw_ArgumentException()
+        public void Install_And_ForProduction_Settings_Specified_Should_Use_Correct_Argument_Provided_In_YarnInstallSettings()
         {
             _fixture.InstallSettings = s => s.ForProduction();
 
             var result = _fixture.Run();
 
-            result.Args.ShouldBe("install --production");
+            result.Args.ShouldBe("install --production=true");
+        }
+
+        [Fact]
+        public void Install_And_ForProduction_False_Settings_Specified_Should_Use_Correct_Argument_Provided_In_YarnInstallSettings()
+        {
+            _fixture.InstallSettings = s => s.ForProduction(false);
+
+            var result = _fixture.Run();
+
+            result.Args.ShouldBe("install --production=false");
         }
 
         [Fact]

--- a/src/Cake.Yarn/YarnInstallSettings.cs
+++ b/src/Cake.Yarn/YarnInstallSettings.cs
@@ -8,6 +8,8 @@ namespace Cake.Yarn
     /// </summary>
     public class YarnInstallSettings : YarnRunnerSettings
     {
+        private bool _explicitProductionFlag;
+
         /// <summary>
         /// Yarn "install" settings
         /// </summary>
@@ -21,9 +23,10 @@ namespace Cake.Yarn
         /// <param name="args"></param>
         protected override void EvaluateCore(ProcessArgumentBuilder args)
         {
-            if (Production)
+            if (_explicitProductionFlag)
             {
-                args.Append("--production");
+                string flag = Production ? "true" : "false";
+                args.Append("--production=" + flag);
             }
 
             if (IgnorePlatform)
@@ -44,6 +47,7 @@ namespace Cake.Yarn
         /// <returns></returns>
         public YarnInstallSettings ForProduction(bool enabled = true)
         {
+            _explicitProductionFlag = true;
             Production = enabled;
             return this;
         }


### PR DESCRIPTION
I am running into a problem where I have an environment where the host environment is setting `NODE_ENV` to production and I need to explicitly set `--production=false` on my `yarn install` command.

This change allows the `install` command to support all three of the scenarios that are possible with the `yarn install` command:  inherited from `NODE_ENV`, explicit true or explicit false.

https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-production