### PR TITLE
Adds support for `yarn version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@
         {
             Yarn.Pack();
         });
+
+    Task("Yarn-Version")
+        .Does(() =>
+        {
+            // yarn version
+            Yarn.Version();
+
+            // yarn version --new-version 0.1.0
+            Yarn.Version(settings => settings.SetVersion("0.1.0"));
+        });
 ```
 
 ## Scope
@@ -53,6 +63,7 @@ Cake.Yarn currently supports the following yarn commands:
 * ```yarn add```
 * ```yarn run```
 * ```yarn pack```
+* ```yarn version```
 
 My primary goal for the project is to support the build workflow I need as a .NET developer, additional features have been contributed
 

--- a/src/Cake.Yarn.Tests/Cake.Yarn.Tests.csproj
+++ b/src/Cake.Yarn.Tests/Cake.Yarn.Tests.csproj
@@ -80,6 +80,8 @@
     <Compile Include="YarnAddTests.cs" />
     <Compile Include="YarnInstallTests.cs" />
     <Compile Include="YarnRunScriptTests.cs" />
+    <Compile Include="YarnVersionFixture.cs" />
+    <Compile Include="YarnVersionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Yarn.Tests/YarnVersionFixture.cs
+++ b/src/Cake.Yarn.Tests/YarnVersionFixture.cs
@@ -1,0 +1,20 @@
+using System;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Yarn.Tests
+{
+    public class YarnVersionFixture : ToolFixture<YarnVersionSettings>
+    {
+        public YarnVersionFixture() : base("yarn")
+        {
+        }
+
+        public Action<YarnVersionSettings> VersionSettings { get; set; }
+
+        protected override void RunTool()
+        {
+            var tool = new YarnRunner(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Version(VersionSettings);
+        }
+    }
+}

--- a/src/Cake.Yarn.Tests/YarnVersionTests.cs
+++ b/src/Cake.Yarn.Tests/YarnVersionTests.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using Xunit;
+
+namespace Cake.Yarn.Tests
+{
+    public class YarnVersionTests
+    {
+        private readonly YarnVersionFixture _fixture;
+
+        public YarnVersionTests()
+        {
+            _fixture = new YarnVersionFixture();
+        }
+
+        [Fact]
+        public void No_Version_Settings_Should_Use_No_Argumemnts()
+        {
+            _fixture.VersionSettings = null;
+
+            var result = _fixture.Run();
+
+            result.Args.ShouldBe("version");
+        }
+
+        [Fact]
+        public void NewVersion_Option_Specified_Should_Use_NewVersion_Argument()
+        {
+            const string generatedVersion = "0.1.0-generated";
+
+            _fixture.VersionSettings = s => s.SetVersion(generatedVersion);
+
+            var result = _fixture.Run();
+
+            result.Args.ShouldBe($"version --new-version \"{generatedVersion}\"");
+        }
+
+        [Fact]
+        public void DisableGitTag_Option_Specified_Should_Use_NoGitTagVersion_Argument()
+        {
+            _fixture.VersionSettings = s => s.DisableGitTagCreation();
+
+            var result = _fixture.Run();
+
+            result.Args.ShouldBe($"version --no-git-tag-version");
+        }
+    }
+}

--- a/src/Cake.Yarn/Cake.Yarn.csproj
+++ b/src/Cake.Yarn/Cake.Yarn.csproj
@@ -53,6 +53,7 @@
     <Compile Include="YarnPackSettings.cs" />
     <Compile Include="YarnRunSettings.cs" />
     <Compile Include="YarnInstallSettings.cs" />
+    <Compile Include="YarnVersionSettings.cs" />
     <Compile Include="YarnRunner.cs" />
     <Compile Include="YarnRunnerAliases.cs" />
     <Compile Include="YarnRunnerSettings.cs" />

--- a/src/Cake.Yarn/YarnRunner.cs
+++ b/src/Cake.Yarn/YarnRunner.cs
@@ -326,6 +326,67 @@ namespace Cake.Yarn
 
         #endregion
 
+        #region yarn version
+
+        /// <summary>
+        /// execute 'yarn version' with options
+        /// </summary>
+        /// <param name="versionSettings">options when running 'yarn version'</param>
+        /// <example>
+        /// <para>Run 'yarn version'</para>
+        /// <code>
+        /// <![CDATA[
+        /// Task("Yarn-Version")
+        ///     .Does(() =>
+        /// {
+        ///     Yarn.Version();
+        /// });
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <para>Run 'yarn version --new-version 0.1.0'</para>
+        /// <code>
+        /// <![CDATA[
+        /// Task("Yarn-Set-Version")
+        ///     .Does(() =>
+        /// {
+        ///     Yarn.Version(settings => settings.SetVersion("0.1.0"));
+        /// });
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <para>Run 'yarn version --no-git-tag-version'</para>
+        /// <code>
+        /// <![CDATA[
+        /// Task("Yarn-Version")
+        ///     .Does(() =>
+        /// {
+        ///     Yarn.Version(settings => settings.DisableGitTagCreation());
+        /// });
+        /// ]]>
+        /// </code>
+        /// </example>
+        public IYarnRunnerCommands Version(Action<YarnVersionSettings> versionSettings = null)
+        {
+            var settings = new YarnVersionSettings();
+            versionSettings?.Invoke(settings);
+            var args = GetYarnVersionArguments(settings);
+
+            Run(settings, args);
+
+            return this;
+        }
+
+        private static ProcessArgumentBuilder GetYarnVersionArguments(YarnVersionSettings settings)
+        {
+            var args = new ProcessArgumentBuilder();
+            settings?.Evaluate(args);
+            return args;
+        }
+        #endregion
+
         /// <summary>
         /// Gets the name of the tool
         /// </summary>

--- a/src/Cake.Yarn/YarnRunnerAliases.cs
+++ b/src/Cake.Yarn/YarnRunnerAliases.cs
@@ -82,6 +82,17 @@ namespace Cake.Yarn
         /// });
         /// ]]>
         /// </code>
+        /// <para>Run 'yarn version'</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// <![CDATA[
+        /// Task("Yarn-Version")
+        ///     .Does(() =>
+        /// {
+        ///     Yarn.Version();
+        /// });
+        /// ]]>
+        /// </code>
         /// </example>
         [CakePropertyAlias]
         public static YarnRunner Yarn(this ICakeContext context)

--- a/src/Cake.Yarn/YarnVersionSettings.cs
+++ b/src/Cake.Yarn/YarnVersionSettings.cs
@@ -1,0 +1,63 @@
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Yarn
+{
+    /// <summary>
+    /// Yarn version options
+    /// </summary>
+    public class YarnVersionSettings : YarnRunnerSettings
+    {
+        /// <summary>
+        /// Yarn "version" settings
+        /// </summary>
+        public YarnVersionSettings() : base("version")
+        {
+        }
+
+        /// <summary>
+        /// Evaluate options
+        /// </summary>
+        /// <param name="args"></param>
+        protected override void EvaluateCore(ProcessArgumentBuilder args)
+        {
+            if (!string.IsNullOrEmpty(NewVersion))
+            {
+                args.Append($"--new-version \"{NewVersion}\"");
+            }
+            if (DisableGitTagVersion) {
+                args.Append("--no-git-tag-version");
+            }
+        }
+
+        /// <summary>
+        /// Applies the --new-version parameter
+        /// </summary>
+        /// <returns></returns>
+        public YarnVersionSettings SetVersion(string newVersion)
+        {
+            NewVersion = newVersion;
+            return this;
+        }
+
+        /// <summary>
+        /// Applies the --no-git-tag-version parameter
+        /// </summary>
+        /// <returns></returns>
+        public YarnVersionSettings DisableGitTagCreation()
+        {
+            DisableGitTagVersion = true;
+            return this;
+        }
+
+        /// <summary>
+        /// --new-version
+        /// </summary>
+        public string NewVersion { get; internal set; }
+
+        /// <summary>
+        /// --no-git-tag-version
+        /// </summary>
+        public bool DisableGitTagVersion { get; internal set; }
+    }
+}

--- a/usage.cake
+++ b/usage.cake
@@ -22,6 +22,9 @@ Task("Default")
 
         // run yarn pack
         Yarn.Pack();
+
+        // run yarn version
+        Yarn.Version(settings => settings.DisableGitTagCreation());
     });
         
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adds support for the `yarn version` command including the `--new-version` and `--no-git-tag-version` options.

Let me know if you have any questions, comments or changes.

**EDIT**: Sorry for the broken builds, I mucked up my local branch, should be good now.