### PR TITLE
Add missing method to `IYarnRunnerCommands` interface (fixes #10)

### DIFF
--- a/src/Cake.Yarn/IYarnRunnerCommands.cs
+++ b/src/Cake.Yarn/IYarnRunnerCommands.cs
@@ -31,5 +31,11 @@ namespace Cake.Yarn
         /// </summary>
         /// <param name="packSettings">options when running 'yarn pack'</param>
         IYarnRunnerCommands Pack(Action<YarnPackSettings> packSettings = null);
+
+        /// <summary>
+        /// execute 'yarn version' with options
+        /// </summary>
+        /// <param name="versionSettings">options when running 'yarn version'</param>
+        IYarnRunnerCommands Version(Action<YarnVersionSettings> versionSettings = null);
     }
 }


### PR DESCRIPTION
Sorry @MilovanovM but I missed the interface declaration as part of #10 so this fixes that up.