### PR TITLE
Add --offline parameter for yarn install

### DIFF
--- a/src/Cake.Yarn.Tests/YarnInstallTests.cs
+++ b/src/Cake.Yarn.Tests/YarnInstallTests.cs
@@ -73,16 +73,27 @@ namespace Cake.Yarn.Tests
         }
 
         [Fact]
+        public void Install_Settings_OfflineInstall_Should_Use_Correct_Argument_Provided_In_YarnInstallSettings()
+        {
+            _fixture.InstallSettings = s => s.Offline();
+
+            var result = _fixture.Run();
+
+            result.Args.ShouldBe("install --offline");
+        }
+
+        [Fact]
         public void Several_Install_Settings_Should_Use_Correct_Argument_Provided_In_YarnInstallSettings()
         {
             _fixture.InstallSettings = s =>
                 s.IgnorePlatformWarnings()
                 .IgnoreEnginesWarnings()
-                .IgnoreOptionalWarnings();
+                .IgnoreOptionalWarnings()
+                .Offline();
 
             var result = _fixture.Run();
 
-            result.Args.ShouldBe("install --ignore-platform --ignore-optional --ignore-engines");
+            result.Args.ShouldBe("install --ignore-platform --ignore-optional --ignore-engines --offline");
         }
     }
 }

--- a/src/Cake.Yarn/YarnInstallSettings.cs
+++ b/src/Cake.Yarn/YarnInstallSettings.cs
@@ -48,13 +48,17 @@ namespace Cake.Yarn
             {
                 args.Append("--frozen-lockfile");
             }
+
+            if (OfflineInstall)
+            {
+                args.Append("--offline");
+            }
         }
 
         /// <summary>
         /// Applies the --production parameter (can not be set when installing individual packages
         /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
+        /// <param name="enabled">The value of the explicitely set production parameter</param>
         public YarnInstallSettings ForProduction(bool enabled = true)
         {
             _explicitProductionFlag = true;
@@ -65,8 +69,7 @@ namespace Cake.Yarn
         /// <summary>
         /// Applies the --ignore-platform parameter
         /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
+        /// <param name="enabled"><c>true</c> to apply the parameter</param>
         public YarnInstallSettings IgnorePlatformWarnings(bool enabled = true)
         {
             IgnorePlatform = enabled;
@@ -76,8 +79,7 @@ namespace Cake.Yarn
         /// <summary>
         /// Applies the --ignore-optional parameter
         /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
+        /// <param name="enabled"><c>true</c> to apply the parameter</param>
         public YarnInstallSettings IgnoreOptionalWarnings(bool enabled = true)
         {
             IgnoreOptional = enabled;
@@ -87,8 +89,7 @@ namespace Cake.Yarn
         /// <summary>
         /// Applies the --ignore-engines parameter
         /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
+        /// <param name="enabled"><c>true</c> to apply the parameter</param>
         public YarnInstallSettings IgnoreEnginesWarnings(bool enabled = true)
         {
             IgnoreEngines = enabled;
@@ -98,11 +99,20 @@ namespace Cake.Yarn
         /// <summary>
         /// Applies the --frozen-lockfile parameter
         /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
+        /// <param name="enabled"><c>true</c> to apply the parameter</param>
         public YarnInstallSettings WithFrozenLockfile(bool enabled = true)
         {
             FrozenLockfile = enabled;
+            return this;
+        }
+
+        /// <summary>
+        /// Applies the --offline parameter
+        /// </summary>
+        /// <param name="enabled"><c>true</c> to apply the parameter</param>
+        public YarnInstallSettings Offline(bool enabled = true)
+        {
+            OfflineInstall = enabled;
             return this;
         }
 
@@ -130,5 +140,10 @@ namespace Cake.Yarn
         /// --frozen-lockfile
         /// </summary>
         public bool FrozenLockfile { get; internal set; }
+
+        /// <summary>
+        /// --offline
+        /// </summary>
+        public bool OfflineInstall { get; internal set; }
     }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.28.1" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
This adds the ability to use the --offline parameter for yarn install commands. It has updates for unit tests as well.