### PR TITLE
Allow any argument to be added to an install command

### DIFF
--- a/src/Cake.Yarn.Tests/YarnInstallTests.cs
+++ b/src/Cake.Yarn.Tests/YarnInstallTests.cs
@@ -83,6 +83,16 @@ namespace Cake.Yarn.Tests
         }
 
         [Fact]
+        public void Install_Settings_WithArgument_Should_Use_Arguments_Provided_In_YarnInstallSettings()
+        {
+            _fixture.InstallSettings = s => s.WithArgument("--verbose").WithArgument("--force");
+
+            var result = _fixture.Run();
+
+            result.Args.ShouldBe("install --verbose --force");
+        }
+
+        [Fact]
         public void Several_Install_Settings_Should_Use_Correct_Argument_Provided_In_YarnInstallSettings()
         {
             _fixture.InstallSettings = s =>

--- a/src/Cake.Yarn/YarnInstallSettings.cs
+++ b/src/Cake.Yarn/YarnInstallSettings.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -9,6 +11,7 @@ namespace Cake.Yarn
     public class YarnInstallSettings : YarnRunnerSettings
     {
         private bool _explicitProductionFlag;
+        private readonly IList<string> _arguments = new List<string>();
 
         /// <summary>
         /// Yarn "install" settings
@@ -52,6 +55,11 @@ namespace Cake.Yarn
             if (OfflineInstall)
             {
                 args.Append("--offline");
+            }
+
+            foreach (var arg in _arguments)
+            {
+                args.Append(arg);
             }
         }
 
@@ -117,6 +125,16 @@ namespace Cake.Yarn
         }
 
         /// <summary>
+        /// Apply any individual argument.
+        /// </summary>
+        /// <param name="arg">The individual argument to use.</param>
+        public YarnInstallSettings WithArgument(string arg)
+        {
+            _arguments.Add(arg);
+            return this;
+        }
+
+        /// <summary>
         /// --production
         /// </summary>
         public bool Production { get; internal set; }
@@ -145,5 +163,10 @@ namespace Cake.Yarn
         /// --offline
         /// </summary>
         public bool OfflineInstall { get; internal set; }
+
+        /// <summary>
+        /// Arguments to pass to the target script
+        /// </summary>
+        public IReadOnlyCollection<string> Arguments => new ReadOnlyCollection<string>(_arguments);
     }
 }


### PR DESCRIPTION
Added the ability to pass any argument you want to the `install` command and added a unit test for it.
Resolves #16.