### PR TITLE
Enable running tool on linux

### DIFF
--- a/src/Cake.Yarn/YarnRunner.cs
+++ b/src/Cake.Yarn/YarnRunner.cs
@@ -27,6 +27,7 @@ namespace Cake.Yarn
     {
         private readonly IFileSystem _fileSystem;
         private DirectoryPath _workingDirectoryPath;
+        private readonly ICakePlatform _platform;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YarnRunner" /> class.
@@ -40,6 +41,7 @@ namespace Cake.Yarn
             : base(fileSystem, environment, processRunner, toolLocator)
         {
             _fileSystem = fileSystem;
+            _platform = environment.Platform;
         }
 
         /// <summary>
@@ -469,8 +471,7 @@ namespace Cake.Yarn
         /// <returns>The tool executable name</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            yield return "yarn.cmd";
-            yield return "yarn";
+            yield return _platform.IsUnix() ? "yarn" : "yarn.cmd";
         }
 
         /// <summary>


### PR DESCRIPTION
The executable name used on linux was yarn.cmd. This caused an
"Exec format error" when running the tool on linux machines.

This change uses the current platform to decide which executable
name to use, and uses "yarn" on linux systems, otherwise "yarn.cmd"

Reproduced the "Exec Format Error" on Windows Subsystem For Linux (WSL),
using the following cake script:

```csharp
#addin "nuget:?package=Cake.Yarn&version=0.4.6"
Task("Default").Does(() => { Yarn.Install(); } );
RunTarget("Default");
```

This script works on windows without any changes.
Verified that the change works correctly on both Windows and Linux.